### PR TITLE
Extensibility for non-writable default PIGO_SCRATCH

### DIFF
--- a/build_images.sh
+++ b/build_images.sh
@@ -6,11 +6,17 @@ SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 pushd "${SOURCE_DIR}"
 
 function build_sif() {
+    SCRATCH_DIR="${SCRATCH_DIR:-/scratch}"
+    if [ ! -d "$SCRATCH_DIR" ] || [ ! -w "$SCRATCH_DIR" ]; then
+        echo "ERROR: SCRATCH_DIR='$SCRATCH_DIR' is not a writable directory" >&2
+        exit 1
+    fi
+
     build_im "$@"
     mkdir -p sifs
     rm -vf sifs/$1.sif
     "$P" image save -o $1.tar $1
-    singularity build sifs/$1.sif "docker-archive://$PWD/$1.tar"
+    singularity build --bind "$SCRATCH_DIR:/scratch" sifs/$1.sif "docker-archive://$PWD/$1.tar"
     rm -v $1.tar
 }
 

--- a/code/test/test.hpp
+++ b/code/test/test.hpp
@@ -1,9 +1,13 @@
 #include <cstdlib>
 #include <cmath>
+#include <cstring>
 #include <iostream>
 #include <exception>
 
 #include <string>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <cerrno>
 
 /**
  * @file tests.hpp
@@ -112,6 +116,15 @@
         std::cout << "Usage: " << argv[0] << " build-dir test-src-dir" <<   \
                 std::endl;                                                  \
         return EXIT_FAILURE;                                                \
+    }                                                                       \
+    {                                                                       \
+        std::string _probe = "/scratch/_pando_test_probe";                  \
+        if (mkdir(_probe.c_str(), 0700) != 0) {                             \
+            std::cerr << "FATAL: /scratch not writable: "                   \
+                << std::strerror(errno) << std::endl;                       \
+            return EXIT_FAILURE;                                            \
+        }                                                                   \
+        rmdir(_probe.c_str());                                              \
     }                                                                       \
     string build_dir {argv[1]};                                             \
     string src_dir {argv[2]};                                               \


### PR DESCRIPTION
Closes #4 .
`BigSpace::BigSpace()` retries `mkdir` indefinitely when `PIGO_SCRATCH` is not writable to the runtime user. The retry is correct for `EEXIST` (random suffix collisions) but not for `EACCES`, where every retry hits the same permission denial. This silently breaks Pando in any deployment where `/scratch` is root-owned, restricted, or bound from a non-writable host directory and produces no actionable diagnostic at the source.
This PR validates writability at two natural choke points so failures surface immediately with clear errors, and introduces a `SCRATCH_DIR` configuration knob so users on non-default systems can override the location.

Changes:
 * `build_images.sh`: `SCRATCH_DIR` validation in `build_sif()`. New `SCRATCH_DIR` environment variable (default`=/scratch`) is validated to exist and be writable before any SIF is built. `singularity build --bind "$SCRATCH_DIR:/scratch"` propagates the bind into the build environment. Users with non-default `/scratch` configurations can override via `SCRATCH_DIR=/tmp ./build_images.sh`.
 * `code/test/test.hpp`: `mkdir`-probe in `TESTS_BEGIN`. A single `mkdir` attempt at `/scratch/_pando_test_probe` runs immediately after the `argc` check; on failure the test binary returns `EXIT_FAILURE` with the `errno` message instead of hanging.